### PR TITLE
added support for lockfileVersion 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# CHANGELOG.md
+
+## 1.0.3 (unreleased)
+
+Fix:
+
+  - added support for lockfileVersion 3
+
+Misc:
+
+  - added CHANGELOG.md

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 import commander from "commander";
 import { readFile, writeFile } from 'fs/promises';
 
-commander.version("1.0.2")
+commander.version("1.0.3")
 	.usage("[options]")
 	.description("Tool to report on packages missing `hasInstallScript` set in `package-lock.json`.  Optionally update the lock file.")
 	.option("--debug",
@@ -32,14 +32,14 @@ if (!commandOptions.fileIn) {
 (async () => {
 	const lockFile = await getData(commandOptions.fileIn);
 	let updated = false;
-	if (lockFile.lockfileVersion && lockFile.lockfileVersion === 2) {
+	if (lockFile.lockfileVersion && [2, 3].includes(lockFile.lockfileVersion)) {
 		const packages = lockFile.packages;
 		for (const entry in packages) {
 			if (entry != "") {
 				debug(`Checking ${entry}`);
 
 				const depsEntry = packages[entry];
-				if (!packages[entry].hasOwnProperty('hasInstallScript')) {
+				if (!depsEntry.hasOwnProperty('hasInstallScript')) {
 					try {
 						const depsPackage = await getData(`${entry}/package.json`);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "fix-has-install-script",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "name": "fix-has-install-script",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0"
       },
       "bin": {
-        "fix-package-lock": "index.js"
+        "fix-has-install-script": "index.js"
       }
     },
     "node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fix-has-install-script",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Report on packages missing `hasInstallScript` set in `package-lock.json`.  Optionally update the lock file.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
This might be handy for people who updated from an old lockfileVersion 1 to lockfileVersion 3 immediately (skipping lockfileVersion 2).

Requesting a review of the changes, since I am not really certain of the differences between lockfileVersion 2 and 3.